### PR TITLE
Fixes and spec-ing out the clear sky shielding

### DIFF
--- a/data/wanderer/new wanderer outfits.txt
+++ b/data/wanderer/new wanderer outfits.txt
@@ -1,13 +1,13 @@
 
-outfit "Clear Sky Shielding"
+outfit "Bright Cloud Shielding"
 	category "Systems"
 	licenses
 		"Wanderer Outfits"
-	cost 180000
+	cost 220000
 	thumbnail "outfit/bright cloud"
-	"mass" 10
-	"outfit space" -10
-	"shield generation" 0.75
-	"shield energy" 1.6
-	"shield heat" 0.2
-	description "This tiny Wanderer shield generator is designed to fit inside their smallest ships and is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other generators and also generates a small amount of heat."
+	"mass" 19
+	"outfit space" -19
+	"shield generation" 1.5
+	"shield energy" 3.0
+	description "This small Wanderer shield generator is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other shield generators do."
+    

--- a/data/wanderer/new wanderer outfits.txt
+++ b/data/wanderer/new wanderer outfits.txt
@@ -1,13 +1,13 @@
 
-outfit "Bright Cloud Shielding"
+outfit "Clear Sky Shielding"
 	category "Systems"
 	licenses
 		"Wanderer Outfits"
-	cost 220000
+	cost 180000
 	thumbnail "outfit/bright cloud"
-	"mass" 19
-	"outfit space" -19
-	"shield generation" 1.5
-	"shield energy" 3.0
-	description "This small Wanderer shield generator is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other shield generators do."
-    
+	"mass" 10
+	"outfit space" -10
+	"shield generation" 0.75
+	"shield energy" 1.6
+	"shield heat" 0.2
+	description "This tiny Wanderer shield generator is designed to fit inside their smallest ships and is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other generators and also generates a small amount of heat."

--- a/data/wanderer/new wanderer outfits.txt
+++ b/data/wanderer/new wanderer outfits.txt
@@ -9,4 +9,5 @@ outfit "Clear Sky Shielding"
 	"outfit space" -10
 	"shield generation" 0.75
 	"shield energy" 1.6
-	description "This tiny Wanderer shield generator is designed to fit inside their smallest ships and is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other generators."
+	"shield heat" 0.2
+	description "This tiny Wanderer shield generator is designed to fit inside their smallest ships and is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other generators and also generates a small amount of heat."

--- a/data/wanderer/new wanderer outfits.txt
+++ b/data/wanderer/new wanderer outfits.txt
@@ -9,5 +9,4 @@ outfit "Clear Sky Shielding"
 	"outfit space" -10
 	"shield generation" 0.75
 	"shield energy" 1.6
-	"shield heat" 0.2
-	description "This tiny Wanderer shield generator is designed to fit inside their smallest ships and is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other generators and also generates a small amount of heat."
+	description "This tiny Wanderer shield generator is designed to fit inside their smallest ships and is able to recharge a ship's shields at a considerable rate, but it also consumes more energy than some other generators."

--- a/data/wanderer/new wanderer outfits.txt
+++ b/data/wanderer/new wanderer outfits.txt
@@ -10,5 +10,3 @@ outfit "Clear Sky Shielding"
 	"shield generation" 0.35
 	"shield energy" 0.6
 	description "To go alongside their wider use of fighter sized ships, the Wanderers have begun producing this tiny shield generator."
-
-    

--- a/data/wanderer/new wanderer ships.txt
+++ b/data/wanderer/new wanderer ships.txt
@@ -70,7 +70,6 @@ ship "Squall"
 	description ""
 
 
-
 ship "Hailstone"
 	sprite "ship/hailstorm"
 	thumbnail "thumbnail/hailstorm"
@@ -79,14 +78,14 @@ ship "Hailstone"
 		licenses
 			"Wanderer Military"
 		"cost" 2000000
-		"shields" 3900
+		"shields" 3600
 		"hull" 2300
 		"required crew" 1
 		"bunks" 1
 		"mass" 25
 		"drag" 0.9
 		"heat dissipation" 1.0
-		"outfit space" 113
+		"outfit space" 119
 		"weapon capacity" 38
 		"engine capacity" 36
 		weapon

--- a/data/wanderer/new wanderer ships.txt
+++ b/data/wanderer/new wanderer ships.txt
@@ -57,10 +57,10 @@ ship "Squall"
 	bay Drone 75.5 18.5
 		angle 20
 		under
-	bay "Drone" -67 100
+	bay Drone -67 100
 		angle 320
 		under
-	bay "Drone" 67 100
+	bay Drone 67 100
 		angle 40
 		under
 	explode "small explosion" 80
@@ -68,7 +68,6 @@ ship "Squall"
 	explode "large explosion" 25
 	"final explode" "final explosion medium" 1
 	description ""
-
 
 
 ship "Hailstone"
@@ -86,7 +85,7 @@ ship "Hailstone"
 		"mass" 25
 		"drag" 0.9
 		"heat dissipation" 1.0
-		"outfit space" 113
+		"outfit space" 114
 		"weapon capacity" 38
 		"engine capacity" 36
 		weapon

--- a/data/wanderer/new wanderer ships.txt
+++ b/data/wanderer/new wanderer ships.txt
@@ -57,10 +57,10 @@ ship "Squall"
 	bay Drone 75.5 18.5
 		angle 20
 		under
-	bay Drone -67 100
+	bay "Drone" -67 100
 		angle 320
 		under
-	bay Drone 67 100
+	bay "Drone" 67 100
 		angle 40
 		under
 	explode "small explosion" 80
@@ -68,6 +68,7 @@ ship "Squall"
 	explode "large explosion" 25
 	"final explode" "final explosion medium" 1
 	description ""
+
 
 
 ship "Hailstone"
@@ -85,7 +86,7 @@ ship "Hailstone"
 		"mass" 25
 		"drag" 0.9
 		"heat dissipation" 1.0
-		"outfit space" 114
+		"outfit space" 113
 		"weapon capacity" 38
 		"engine capacity" 36
 		weapon

--- a/data/wanderer/wanderers part 3.txt
+++ b/data/wanderer/wanderers part 3.txt
@@ -19,10 +19,10 @@ mission "Wanderers: Sabira Eseskrai Meeting"
 			label gaps
 			choice
 				`	"I suppose you're filling in the gaps?"`
-			`	"Indeed. To that end, I'd like to make a request of you, but first, our leaders here, both Wanderer and Korath, are going to be metting shortly and we'd like you to join us."`
+			`	"Indeed. To that end, I'd like to make a request of you, but first, our leaders here, both Wanderer and Korath, are going to be metting shortly and we'd like you to join us."
 			choice
 				`	"Can't you tell me on the way?"`
-			`	She acquiesces and explains, "The Molt has given me the ability to relatively quickly learn the Korath language, however we cannot assume it will do the same for all others. I would like to visit the man you got your speaking translator from, I'm hoping between his linguistic work, my own experiences with the Korath, and one of our artificial minds, it will be possible to develop a translator between the Wanderer or Hai and Korath languages."`
+			`	She acquiesces and explains, "The Molt has given me the ability to relatively quickly learn the Korath language, however we cannot assume it will do the same for all others. I would like to visit the man you got your speaking translator from, I'm hoping between his linguistic work, my own experiences with the Korath, and one of our artificial minds, it will be possible to deveelop a translator between the Wanderer or Hai and Korath languages."`
 			`	She leads you to one of the larger buildings in the settlement, apparently akin to a town hall of sorts, inside are a number of Wanderers and Kor Efret, some standing, some sitting, arranged in a circle. The Wanderers form one half, the Korath form the other. Many of the Wanderers do not look quite right to you, but you're not sure what exactly it is. You recognise Tema'a Iriket, the terraforming specialist, but are surprised to see that Sobari Tele'ek, who has played a significant role in the Wanderers' development on this side of the Eye up until now, is not present.`
 			`	A few more filter in over the next few minutes. Once everyone has arrived and settled down, you are somewhat surprised to see that one of the Korath takes the lead and starts speaking. After it is done, Rek begins speaking to the rest of the Wanderers in their own language. They all seem to respond positively and one of them speaks to the Korath, with Rek as translator. Unfortunately, not in the Hai language so your translator cannot help and Rek seems too busy, now that the discussion is developing further with someone speaking, and needing translation, almost continuously.`
 			`	After several minutes, one of the Korath gestures to you while speaking, and Rek finally brings you in on the discussion, "He thanks you for your contributions to our efforts to make this territory safer, by eliminating hte threat of the war machines, and rejuvenating these worlds through your help to us and was wondering if you'd be willing to assist the Efreti more directly?"`
@@ -51,6 +51,7 @@ mission "Wanderers: Sabira Eseskrai Meeting"
 			choice
 				`	"I noticed Sobari Tele'ek was missing from the meeting. Is he managing the defense against the Hai?"`
 			`	"As you may know, Tele'ek was nearing the Molt while we were still dealing with the Kor Sestor drones. Since their factories have been shut down, and there are no longer any immediate threats to us here, he has recently elected to stop resisting and allow the Molt to take its course. Once it is done, he will be only the second since the Eye opened."`
+			`	
 
 mission "Wanderers: Korath Translator 1"
 	name "Collect Sayari"

--- a/data/wanderer/wanderers part 3.txt
+++ b/data/wanderer/wanderers part 3.txt
@@ -19,7 +19,7 @@ mission "Wanderers: Sabira Eseskrai Meeting"
 			label gaps
 			choice
 				`	"I suppose you're filling in the gaps?"`
-			`	"Indeed. To that end, I'd like to make a request of you, but first, our leaders here, both Wanderer and Korath, are going to be metting shortly and we'd like you to join us."
+			`	"Indeed. To that end, I'd like to make a request of you, but first, our leaders here, both Wanderer and Korath, are going to be metting shortly and we'd like you to join us."`
 			choice
 				`	"Can't you tell me on the way?"`
 			`	She acquiesces and explains, "The Molt has given me the ability to relatively quickly learn the Korath language, however we cannot assume it will do the same for all others. I would like to visit the man you got your speaking translator from, I'm hoping between his linguistic work, my own experiences with the Korath, and one of our artificial minds, it will be possible to deveelop a translator between the Wanderer or Hai and Korath languages."`
@@ -51,7 +51,6 @@ mission "Wanderers: Sabira Eseskrai Meeting"
 			choice
 				`	"I noticed Sobari Tele'ek was missing from the meeting. Is he managing the defense against the Hai?"`
 			`	"As you may know, Tele'ek was nearing the Molt while we were still dealing with the Kor Sestor drones. Since their factories have been shut down, and there are no longer any immediate threats to us here, he has recently elected to stop resisting and allow the Molt to take its course. Once it is done, he will be only the second since the Eye opened."`
-			`	
 
 mission "Wanderers: Korath Translator 1"
 	name "Collect Sayari"
@@ -86,7 +85,3 @@ mission "Wanderers: Korath Translator 1A"
 	on offer
 		conversation
 			`As you make your way to the planet, you note that this system is very active, with many cargo and transport ships going in all directions, the logistics of moving an entire species from one set of planets to another via a wormhole in a single system must be an incredible logistical challenge, especially when the destination systems can barely support life. This is something the Wanderers have done many times, probably more than you can count, maybe more than they can, and the patterns you start to see emerge in the movements of the ships around you show that this is a well choreographed operation. You also note a number of much smaller craft you don't recognise, interceptor sized, perhaps, travelling to the east, into the border with the Unfettered Hai, guarded by the two advanced Pug warships."`
-			`	
-
-			
-

--- a/data/wanderer/wanderers part 3.txt
+++ b/data/wanderer/wanderers part 3.txt
@@ -19,10 +19,10 @@ mission "Wanderers: Sabira Eseskrai Meeting"
 			label gaps
 			choice
 				`	"I suppose you're filling in the gaps?"`
-			`	"Indeed. To that end, I'd like to make a request of you, but first, our leaders here, both Wanderer and Korath, are going to be metting shortly and we'd like you to join us."
+			`	"Indeed. To that end, I'd like to make a request of you, but first, our leaders here, both Wanderer and Korath, are going to be metting shortly and we'd like you to join us."`
 			choice
 				`	"Can't you tell me on the way?"`
-			`	She acquiesces and explains, "The Molt has given me the ability to relatively quickly learn the Korath language, however we cannot assume it will do the same for all others. I would like to visit the man you got your speaking translator from, I'm hoping between his linguistic work, my own experiences with the Korath, and one of our artificial minds, it will be possible to deveelop a translator between the Wanderer or Hai and Korath languages."`
+			`	She acquiesces and explains, "The Molt has given me the ability to relatively quickly learn the Korath language, however we cannot assume it will do the same for all others. I would like to visit the man you got your speaking translator from, I'm hoping between his linguistic work, my own experiences with the Korath, and one of our artificial minds, it will be possible to develop a translator between the Wanderer or Hai and Korath languages."`
 			`	She leads you to one of the larger buildings in the settlement, apparently akin to a town hall of sorts, inside are a number of Wanderers and Kor Efret, some standing, some sitting, arranged in a circle. The Wanderers form one half, the Korath form the other. Many of the Wanderers do not look quite right to you, but you're not sure what exactly it is. You recognise Tema'a Iriket, the terraforming specialist, but are surprised to see that Sobari Tele'ek, who has played a significant role in the Wanderers' development on this side of the Eye up until now, is not present.`
 			`	A few more filter in over the next few minutes. Once everyone has arrived and settled down, you are somewhat surprised to see that one of the Korath takes the lead and starts speaking. After it is done, Rek begins speaking to the rest of the Wanderers in their own language. They all seem to respond positively and one of them speaks to the Korath, with Rek as translator. Unfortunately, not in the Hai language so your translator cannot help and Rek seems too busy, now that the discussion is developing further with someone speaking, and needing translation, almost continuously.`
 			`	After several minutes, one of the Korath gestures to you while speaking, and Rek finally brings you in on the discussion, "He thanks you for your contributions to our efforts to make this territory safer, by eliminating hte threat of the war machines, and rejuvenating these worlds through your help to us and was wondering if you'd be willing to assist the Efreti more directly?"`
@@ -51,7 +51,6 @@ mission "Wanderers: Sabira Eseskrai Meeting"
 			choice
 				`	"I noticed Sobari Tele'ek was missing from the meeting. Is he managing the defense against the Hai?"`
 			`	"As you may know, Tele'ek was nearing the Molt while we were still dealing with the Kor Sestor drones. Since their factories have been shut down, and there are no longer any immediate threats to us here, he has recently elected to stop resisting and allow the Molt to take its course. Once it is done, he will be only the second since the Eye opened."`
-			`	
 
 mission "Wanderers: Korath Translator 1"
 	name "Collect Sayari"


### PR DESCRIPTION
I've added a few suggested values for the clear sky shielding based on the current figures for the wanderer shields (slightly lower mass efficiency than bright cloud, less energy efficient, and creates some heat).

I've also added some fixes concerning quotations (there were a few rouge backticks that I've removed), extra empty lines and mixed indentation (4 spaces instead of a tab character).

I've increased the hailstone's outfit space by 1 so that it fits all it's outfits.

I know that you've added a clear sky shielding in your other repo, but isn't 5 tonnes a little light? The current smallest is the coalition small generation module at 11 tonnes. It also doesn't seem to consume enough power for wanderer shields and costs too much per tonne.

Just some food for thought.